### PR TITLE
show error last

### DIFF
--- a/load.go
+++ b/load.go
@@ -54,8 +54,8 @@ func LoadWith(cfg interface{}, ld Loader) (args []string) {
 		ld.PrintHelp(cfg)
 		os.Exit(0)
 	default:
-		ld.PrintError(err)
 		ld.PrintHelp(cfg)
+		ld.PrintError(err)
 		os.Exit(1)
 	}
 	return


### PR DESCRIPTION
@f2prateek 
@tejasmanohar 
@andreiko 

Show the error last, so when the help message is longer that what the term can display the user still sees what went wrong right away (no need to scroll up).