### PR TITLE
Sources

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -1,0 +1,68 @@
+package conf
+
+import (
+	"flag"
+	"io/ioutil"
+	"reflect"
+
+	"github.com/segmentio/objconv"
+)
+
+func newFlagSet(cfg reflect.Value, name string, sources ...Source) *flag.FlagSet {
+	set := flag.NewFlagSet(name, flag.ContinueOnError)
+	set.SetOutput(ioutil.Discard)
+
+	scanFields(cfg, "", ".", func(key string, help string, val reflect.Value) {
+		set.Var(makeFlagValue(val), key, help)
+	})
+
+	for _, source := range sources {
+		if f, ok := source.(FlagSource); ok {
+			set.Var(f, f.Flag(), f.Help())
+		}
+	}
+
+	return set
+}
+
+func scanFields(v reflect.Value, base string, sep string, do func(string, string, reflect.Value)) {
+	t := v.Type()
+
+	for i, n := 0, v.NumField(); i != n; i++ {
+		ft := t.Field(i)
+		fv := v.Field(i)
+
+		name := ft.Name
+		help := ft.Tag.Get("help")
+		tag, _, _ := objconv.ParseTag(ft.Tag.Get("objconv"))
+
+		if tag == "-" {
+			continue
+		}
+
+		if len(tag) != 0 {
+			name = tag
+		}
+
+		if len(base) != 0 {
+			name = base + sep + name
+		}
+
+		// Dereference all pointers and create objects on the ones that are nil.
+		for fv.Kind() == reflect.Ptr {
+			if fv.IsNil() {
+				fv.Set(reflect.New(ft.Type.Elem()))
+			}
+			fv = fv.Elem()
+		}
+
+		// For all fields the delegate is called.
+		do(name, help, fv)
+
+		// Inner structs are flattened to allow composition of configuration
+		// objects.
+		if fv.Kind() == reflect.Struct && !specialType(ft.Type) {
+			scanFields(fv, name, sep, do)
+		}
+	}
+}

--- a/load.go
+++ b/load.go
@@ -1,18 +1,15 @@
 package conf
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
-	"html/template"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 
-	"github.com/segmentio/objconv"
-	"github.com/segmentio/objconv/yaml"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // Load the program's configuration into cfg, and returns the list of leftover
@@ -34,14 +31,7 @@ import (
 // If an error is detected with the configurable the function print the usage
 // message to stderr and exit with status code 1.
 func Load(cfg interface{}) (args []string) {
-	var env = os.Environ()
-	return LoadWith(cfg, Loader{
-		Args:     os.Args[1:],
-		Env:      env,
-		Vars:     makeEnvVars(env),
-		Program:  filepath.Base(os.Args[0]),
-		FileFlag: "config-file",
-	})
+	return LoadWith(cfg, defaultLoader(os.Args, os.Environ()))
 }
 
 // LoadWith behaves like Load but uses ld as a loader to parse the program
@@ -64,11 +54,9 @@ func LoadWith(cfg interface{}, ld Loader) (args []string) {
 // A Loader can be used to provide a costomized configurable for loading a
 // configuration.
 type Loader struct {
-	Args     []string    // list of arguments
-	Env      []string    // list of environment variables ["KEY=VALUE", ...]
-	Vars     interface{} // template variables, may be a struct, map, etc..
-	Program  string      // name of the program
-	FileFlag string      // command line option for the configuration file
+	Name    string   // program name
+	Args    []string // list of arguments
+	Sources []Source // list of sources to load configuration from.
 }
 
 // Load uses the loader ld to load the program configuration into cfg, and
@@ -109,168 +97,43 @@ func (ld Loader) Load(cfg interface{}) (args []string, err error) {
 }
 
 func (ld Loader) load(cfg reflect.Value) (args []string, err error) {
-	if err = loadFile(cfg, ld.Program, ld.FileFlag, ld.Args, ld.Vars, ioutil.ReadFile); err != nil {
-		args = nil
+	set := newFlagSet(cfg, ld.Name, ld.Sources...)
+
+	// Parse the arguments a first time so the sources that implement the
+	// FlagSource interface get their values loaded.
+	if err = set.Parse(ld.Args); err != nil {
 		return
 	}
 
-	if err = loadEnv(cfg, ld.Program, ld.Env); err != nil {
-		args = nil
+	// Load the configuration from the sources that have been configured on the
+	// loader.
+	// Order is important here because the values will get overwritten by each
+	// source that loads the configuration.
+	for _, source := range ld.Sources {
+		if err = source.Load(cfg.Addr().Interface()); err != nil {
+			return
+		}
+	}
+
+	// Parse the arguments a second time to overwrite values loaded by sources
+	// which were also passed to the program arguments.
+	if err = set.Parse(ld.Args); err != nil {
 		return
 	}
 
-	return loadArgs(cfg, ld.Program, ld.FileFlag, ld.Args)
-}
-
-func loadFile(cfg reflect.Value, name string, fileFlag string, args []string, vars interface{}, readFile func(string) ([]byte, error)) (err error) {
-	if len(fileFlag) != 0 {
-		var a = append([]string{}, args...)
-		var b []byte
-		var f string
-		var v = deepCopyValue(cfg)
-
-		set := newFlagSet(v, name)
-		addFileFlag(set, &f, fileFlag)
-
-		if err = set.Parse(a); err != nil {
-			return
-		}
-
-		if len(f) == 0 {
-			return
-		}
-
-		if b, err = readFile(f); err != nil {
-			return
-		}
-
-		tpl := template.New("config")
-		buf := &bytes.Buffer{}
-		buf.Grow(65536)
-
-		if _, err = tpl.Parse(string(b)); err != nil {
-			return
-		}
-
-		if err = tpl.Execute(buf, vars); err != nil {
-			return
-		}
-
-		if err = yaml.Unmarshal(buf.Bytes(), cfg.Addr().Interface()); err != nil {
-			return
-		}
-	}
+	args = set.Args()
 	return
 }
 
-func loadEnv(cfg reflect.Value, name string, env []string) (err error) {
-	if len(env) != 0 {
-		type entry struct {
-			key string
-			val flagValue
-		}
-		var entries []entry
-
-		scanFields(cfg, name, "_", func(key string, help string, val reflect.Value) {
-			entries = append(entries, entry{
-				key: snakecaseUpper(key) + "=",
-				val: makeFlagValue(val),
-			})
-		})
-
-		for _, e := range entries {
-			for _, kv := range env {
-				if strings.HasPrefix(kv, e.key) {
-					if err = e.val.Set(kv[len(e.key):]); err != nil {
-						return
-					}
-					break
-				}
-			}
-		}
-	}
-	return
-}
-
-func loadArgs(cfg reflect.Value, name string, fileFlag string, args []string) (leftover []string, err error) {
-	if len(args) != 0 {
-		args = append([]string{}, args...)
-		set := newFlagSet(cfg, name)
-
-		if len(fileFlag) != 0 {
-			addFileFlag(set, nil, fileFlag)
-		}
-
-		if err = set.Parse(args); err != nil {
-			return
-		}
-
-		leftover = set.Args()
-	}
-	return
-}
-
-func newFlagSet(cfg reflect.Value, name string) *flag.FlagSet {
-	set := flag.NewFlagSet(name, flag.ContinueOnError)
-	set.SetOutput(ioutil.Discard)
-
-	scanFields(cfg, "", ".", func(key string, help string, val reflect.Value) {
-		set.Var(makeFlagValue(val), key, help)
-	})
-
-	return set
-}
-
-func addFileFlag(set *flag.FlagSet, f *string, arg string) {
-	if f == nil {
-		f = new(string)
-	}
-	set.Var(makeFlagValue(reflect.ValueOf(f).Elem()), arg, "Path to the configuration file")
-}
-
-func scanFields(v reflect.Value, base string, sep string, do func(string, string, reflect.Value)) {
-	t := v.Type()
-
-	for i, n := 0, v.NumField(); i != n; i++ {
-		ft := t.Field(i)
-		fv := v.Field(i)
-
-		if len(ft.PkgPath) != 0 {
-			continue // unexported field
-		}
-
-		name := ft.Name
-		help := ft.Tag.Get("help")
-		tag, _, _ := objconv.ParseTag(ft.Tag.Get("objconv"))
-
-		if tag == "-" {
-			continue
-		}
-
-		if len(tag) != 0 {
-			name = tag
-		}
-
-		if len(base) != 0 {
-			name = base + sep + name
-		}
-
-		// Dereference all pointers and create objects on the ones that are nil.
-		for fv.Kind() == reflect.Ptr {
-			if fv.IsNil() {
-				fv.Set(reflect.New(ft.Type.Elem()))
-			}
-			fv = fv.Elem()
-		}
-
-		// For all fields the delegate is called.
-		do(name, help, fv)
-
-		// Inner structs are flattened to allow composition of configuration
-		// objects.
-		if fv.Kind() == reflect.Struct && !specialType(ft.Type) {
-			scanFields(fv, name, sep, do)
-		}
+func defaultLoader(args []string, env []string) Loader {
+	var name = filepath.Base(args[0])
+	return Loader{
+		Name: name,
+		Args: args[1:],
+		Sources: []Source{
+			NewFileSource("config-file", makeEnvVars(env), ioutil.ReadFile, yaml.Unmarshal),
+			NewEnvSource(name, env...),
+		},
 	}
 }
 

--- a/load.go
+++ b/load.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"strings"
 
-	yaml "gopkg.in/yaml.v2"
+	"github.com/segmentio/objconv/yaml"
 )
 
 // Load the program's configuration into cfg, and returns the list of leftover

--- a/load_test.go
+++ b/load_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	yaml "gopkg.in/yaml.v2"
+	"github.com/segmentio/objconv/yaml"
 )
 
 type point struct {

--- a/load_test.go
+++ b/load_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/objconv/json"
+	yaml "gopkg.in/yaml.v2"
 )
 
 type point struct {
@@ -183,91 +183,33 @@ var (
 	}
 )
 
-func testName(v interface{}) string {
-	b, _ := json.Marshal(v)
-	return string(b)
-}
-
-/*
-func TestLoadEnv(t *testing.T) {
+func TestLoad(t *testing.T) {
 	for _, test := range loadTests {
-		t.Run(testName(test.val), func(t *testing.T) {
-			v1 := reflect.ValueOf(test.val)
-			v2 := reflect.New(v1.Type()).Elem()
-			v3 := makeValue(v1)
-			setValue(v3, v2)
+		t.Run("", func(t *testing.T) {
+			ld := Loader{
+				Name: "test",
+				Args: test.args,
+				Sources: []Source{
+					SourceFunc(func(dst interface{}) (err error) { return yaml.Unmarshal([]byte(test.file), dst) }),
+					NewEnvSource("test", test.env...),
+				},
+			}
 
-			if err := loadEnv(v3, "test", test.env); err != nil {
+			val := reflect.New(reflect.TypeOf(test.val)).Elem()
+
+			if _, err := ld.Load(val.Addr().Interface()); err != nil {
 				t.Error(err)
-			}
-
-			setValue(v2, v3)
-			x1 := v1.Interface()
-			x2 := v2.Interface()
-
-			if !reflect.DeepEqual(x1, x2) {
-				t.Errorf("\n<<< %#v\n>>> %#v", x1, x2)
-			}
-		})
-	}
-}
-
-func TestLoadArgs(t *testing.T) {
-	for _, test := range loadTests {
-		t.Run(testName(test.val), func(t *testing.T) {
-			v1 := reflect.ValueOf(test.val)
-			v2 := reflect.New(v1.Type()).Elem()
-			v3 := makeValue(v1)
-			setValue(v3, v2)
-
-			if _, err := loadArgs(v3, "test", "", test.args); err != nil {
-				t.Error(err)
-			}
-
-			setValue(v2, v3)
-			x1 := v1.Interface()
-			x2 := v2.Interface()
-
-			if !reflect.DeepEqual(x1, x2) {
-				t.Errorf("\n<<< %#v\n>>> %#v", x1, x2)
-			}
-		})
-	}
-}
-
-func TestLoadFile(t *testing.T) {
-	for _, test := range loadTests {
-		t.Run(testName(test.val), func(t *testing.T) {
-			v1 := reflect.ValueOf(test.val)
-			v2 := reflect.New(v1.Type()).Elem()
-			v3 := makeValue(v1)
-			setValue(v3, v2)
-
-			readFile := func(file string) (b []byte, err error) {
-				if file != "test.yml" {
-					t.Error(file)
-				}
-				b = []byte(test.file)
 				return
 			}
 
-			if err := loadFile(v3, "test", "config-file", []string{"-config-file", "test.yml"}, nil, readFile); err != nil {
-				t.Error(err)
-			}
-
-			setValue(v2, v3)
-			x1 := v1.Interface()
-			x2 := v2.Interface()
-
-			if !reflect.DeepEqual(x1, x2) {
-				t.Errorf("\n<<< %#v\n>>> %#v", x1, x2)
+			if !reflect.DeepEqual(test.val, val.Interface()) {
+				t.Errorf("bad value:\n<<< %#v\n>>> %#v", test.val, val.Interface())
 			}
 		})
 	}
 }
-*/
 
-func TestLoad(t *testing.T) {
+func TestDefaultLoader(t *testing.T) {
 	const configFile = "/tmp/conf-test.yml"
 	ioutil.WriteFile(configFile, []byte(`---
 points:

--- a/print.go
+++ b/print.go
@@ -51,14 +51,10 @@ func (ld Loader) fprintHelp(w io.Writer, cfg interface{}, col colors) {
 		panic(fmt.Sprintf("cannot load configuration into %T", cfg))
 	}
 
-	set := newFlagSet(makeValue(v), ld.Program)
-
-	if len(ld.FileFlag) != 0 {
-		addFileFlag(set, nil, ld.FileFlag)
-	}
+	set := newFlagSet(makeValue(v), ld.Name, ld.Sources...)
 
 	fmt.Fprintf(w, "%s\n", col.titles("Usage:"))
-	fmt.Fprintf(w, "  %s [-h] [-help] [options...]\n\n", ld.Program)
+	fmt.Fprintf(w, "  %s [-h] [-help] [options...]\n\n", ld.Name)
 
 	fmt.Fprintf(w, "%s\n", col.titles("Options:"))
 

--- a/print_test.go
+++ b/print_test.go
@@ -76,9 +76,8 @@ func TestPrintError(t *testing.T) {
 
 func TestPrintHelp(t *testing.T) {
 	ld := Loader{
-		Args:     []string{"-A=1", "-B=2", "-C=3"},
-		Program:  "test",
-		FileFlag: "F",
+		Name: "test",
+		Args: []string{"-A=1", "-B=2", "-C=3"},
 	}
 	b := &bytes.Buffer{}
 
@@ -103,9 +102,6 @@ func TestPrintHelp(t *testing.T) {
 		"  -C int\n" +
 		"\n" +
 		"  -D\tSet D\n" +
-		"\n" +
-		"  -F string\n" +
-		"    \tPath to the configuration file\n" +
 		"\n" +
 		"  -T duration\n" +
 		"    \t(default 1s)\n" +

--- a/source.go
+++ b/source.go
@@ -8,26 +8,47 @@ import (
 	"strings"
 )
 
+// Source is the interface that allow new types to be plugged into a loader to
+// make it possible to load configuration from new places.
+//
+// When the configuration is loaded the Load method of each source that was set
+// on a loader is called with a pointer to an in-memory structure representing
+// the configuration object passed as dst.
 type Source interface {
 	Load(dst interface{}) error
 }
 
+// FlagSource is a special case of a source that receives a configuration value
+// from the arguments of a loader. It makes it possible to provide runtime
+// configuration to the source from the command line arguments of a program.
 type FlagSource interface {
 	Source
 
+	// Flag is the name of the flag that sets the source's configuration value.
 	Flag() string
 
+	// Help is called to get the help message to display for the source's flag.
 	Help() string
 
+	// flag.Value must be implemented by a FlagSource to receive their value
+	// when the loader's arguments are parsed.
 	flag.Value
 }
 
+// SourceFunc makes it possible to use basic function types as configuration
+// sources.
 type SourceFunc func(dst interface{}) error
 
+// Load calls f.
 func (f SourceFunc) Load(dst interface{}) error {
 	return f(dst)
 }
 
+// NewEnvSource creates a new source which loads values from the environment
+// variables given in env.
+//
+// A prefix may be set to namespace the environment variables that the source
+// will be looking at.
 func NewEnvSource(prefix string, env ...string) Source {
 	return SourceFunc(func(dst interface{}) (err error) {
 		if len(env) != 0 {
@@ -59,7 +80,21 @@ func NewEnvSource(prefix string, env ...string) Source {
 	})
 }
 
-func NewFileSource(flag string, vars interface{}, readFile func(string) ([]byte, error), unmarshal func([]byte, interface{}) error) Source {
+// NewFileSource creates a new source which loads a configuration from a file
+// identified by a path (or URL).
+//
+// The returned source satisfies the FlagSource interface because it loads the
+// file location from the given flag.
+//
+// The vars argument may be set to render the configuration file if it's a
+// template.
+//
+// The readFile function loads the file content in-memory from a file location
+// given as argument, usually this is ioutil.ReadFile.
+//
+// The unmarshal function decodes the content of the configuration file into a
+// configuration object.
+func NewFileSource(flag string, vars interface{}, readFile func(string) ([]byte, error), unmarshal func([]byte, interface{}) error) FlagSource {
 	return &fileSource{
 		flag:      flag,
 		vars:      vars,

--- a/source.go
+++ b/source.go
@@ -1,0 +1,121 @@
+package conf
+
+import (
+	"bytes"
+	"flag"
+	"html/template"
+	"reflect"
+	"strings"
+)
+
+type Source interface {
+	Load(dst interface{}) error
+}
+
+type FlagSource interface {
+	Source
+
+	Flag() string
+
+	Help() string
+
+	flag.Value
+}
+
+type SourceFunc func(dst interface{}) error
+
+func (f SourceFunc) Load(dst interface{}) error {
+	return f(dst)
+}
+
+func NewEnvSource(prefix string, env ...string) Source {
+	return SourceFunc(func(dst interface{}) (err error) {
+		if len(env) != 0 {
+			type entry struct {
+				key string
+				val flagValue
+			}
+			var entries []entry
+
+			scanFields(reflect.ValueOf(dst).Elem(), prefix, "_", func(key string, help string, val reflect.Value) {
+				entries = append(entries, entry{
+					key: snakecaseUpper(key) + "=",
+					val: makeFlagValue(val),
+				})
+			})
+
+			for _, e := range entries {
+				for _, kv := range env {
+					if strings.HasPrefix(kv, e.key) {
+						if err = e.val.Set(kv[len(e.key):]); err != nil {
+							return
+						}
+						break
+					}
+				}
+			}
+		}
+		return
+	})
+}
+
+func NewFileSource(flag string, vars interface{}, readFile func(string) ([]byte, error), unmarshal func([]byte, interface{}) error) Source {
+	return &fileSource{
+		flag:      flag,
+		vars:      vars,
+		readFile:  readFile,
+		unmarshal: unmarshal,
+	}
+}
+
+type fileSource struct {
+	flag      string
+	path      string
+	vars      interface{}
+	readFile  func(string) ([]byte, error)
+	unmarshal func([]byte, interface{}) error
+}
+
+func (f *fileSource) Load(dst interface{}) (err error) {
+	var b []byte
+
+	if len(f.path) == 0 {
+		return
+	}
+
+	if b, err = f.readFile(f.path); err != nil {
+		return
+	}
+
+	tpl := template.New(f.flag)
+	buf := &bytes.Buffer{}
+	buf.Grow(len(b))
+
+	if _, err = tpl.Parse(string(b)); err != nil {
+		return
+	}
+
+	if err = tpl.Execute(buf, f.vars); err != nil {
+		return
+	}
+
+	err = f.unmarshal(buf.Bytes(), dst)
+	return
+}
+
+func (f *fileSource) Flag() string {
+	return f.flag
+}
+
+func (f *fileSource) Help() string {
+	return "Location to load the configuration file from."
+}
+
+func (f *fileSource) Set(s string) error {
+	f.path = s
+	return nil
+}
+
+func (f *fileSource) String() string {
+	return f.path
+}

--- a/type.go
+++ b/type.go
@@ -64,10 +64,12 @@ func specialType(t reflect.Type) bool {
 
 func makeStructType(t reflect.Type) reflect.Type {
 	n := t.NumField()
-	f := make([]reflect.StructField, n)
+	f := make([]reflect.StructField, 0, n)
 
 	for i := 0; i != n; i++ {
-		f[i] = makeStructField(t.Field(i))
+		if ft := t.Field(i); isExported(ft) {
+			f = append(f, makeStructField(ft))
+		}
 	}
 
 	return reflect.StructOf(f)
@@ -81,4 +83,8 @@ func makeStructField(f reflect.StructField) reflect.StructField {
 		Tag:       reflect.StructTag(strings.Replace(string(f.Tag), "conf:", "objconv:", -1)),
 		Anonymous: f.Anonymous,
 	}
+}
+
+func isExported(f reflect.StructField) bool {
+	return len(f.PkgPath) == 0
 }


### PR DESCRIPTION
@f2prateek 
@tejasmanohar 
@andreiko 

Prateek had a discussion around the need for being able to customize where the program loads its configuration from.

Because this includes some non-backward compatible changes I wanted to get it out as quickly as possible while we don't have too many dependencies yet. Note that the basic use case is left unchanged, code that just relies on `conf.Load` will compile and run as expected.

The way it works is by configuration a `conf.Loader` with a list of values that implement the `conf.Source` or `conf.FlagSource` interface. The documentation for each of them in in the files bellow.

Overall I believe this change is good because the implementation looks much cleaner, I was able to get rid of some code to cover special cases I had before, and add more tests.

Please take a look and let me know if you have any concerns.