### PR TITLE
add support for the validate tag

### DIFF
--- a/load.go
+++ b/load.go
@@ -143,38 +143,7 @@ func (ld Loader) Load(cfg interface{}) (cmd string, args []string, err error) {
 	setValue(v1, v2)
 
 	if err = validator.Validate(v1.Interface()); err != nil {
-		if errmap, ok := err.(validator.ErrorMap); ok {
-			errkeys := make([]string, 0, len(errmap))
-			errlist := make(errorList, 0, len(errmap))
-
-			for errkey := range errmap {
-				errkeys = append(errkeys, errkey)
-			}
-
-			sort.Strings(errkeys)
-
-			for _, errkey := range errkeys {
-				path := fieldPath(v1.Type(), errkey)
-
-				if len(errmap[errkey]) == 1 {
-					errlist = append(errlist, fmt.Errorf("invalid value passed to %s: %s", path, errmap[errkey][0]))
-				} else {
-					buf := &bytes.Buffer{}
-					fmt.Fprintf(buf, "invalid value passed to %s: ", path)
-
-					for i, errval := range errmap[errkey] {
-						if i != 0 {
-							buf.WriteString("; ")
-						}
-						buf.WriteString(errval.Error())
-					}
-
-					errlist = append(errlist, errors.New(buf.String()))
-				}
-			}
-
-			err = errlist
-		}
+		err = makeValidationError(err, v1)
 	}
 
 	return
@@ -238,6 +207,42 @@ func makeEnvVars(env []string) (vars map[string]string) {
 	}
 
 	return vars
+}
+
+func makeValidationError(err error, v reflect.Value) error {
+	if errmap, ok := err.(validator.ErrorMap); ok {
+		errkeys := make([]string, 0, len(errmap))
+		errlist := make(errorList, 0, len(errmap))
+
+		for errkey := range errmap {
+			errkeys = append(errkeys, errkey)
+		}
+
+		sort.Strings(errkeys)
+
+		for _, errkey := range errkeys {
+			path := fieldPath(v.Type(), errkey)
+
+			if len(errmap[errkey]) == 1 {
+				errlist = append(errlist, fmt.Errorf("invalid value passed to %s: %s", path, errmap[errkey][0]))
+			} else {
+				buf := &bytes.Buffer{}
+				fmt.Fprintf(buf, "invalid value passed to %s: ", path)
+
+				for i, errval := range errmap[errkey] {
+					if i != 0 {
+						buf.WriteString("; ")
+					}
+					buf.WriteString(errval.Error())
+				}
+
+				errlist = append(errlist, errors.New(buf.String()))
+			}
+		}
+
+		err = errlist
+	}
+	return err
 }
 
 type errorList []error

--- a/load.go
+++ b/load.go
@@ -143,7 +143,7 @@ func (ld Loader) Load(cfg interface{}) (cmd string, args []string, err error) {
 	setValue(v1, v2)
 
 	if err = validator.Validate(v1.Interface()); err != nil {
-		err = makeValidationError(err, v1)
+		err = makeValidationError(err, v1.Type())
 	}
 
 	return
@@ -209,7 +209,7 @@ func makeEnvVars(env []string) (vars map[string]string) {
 	return vars
 }
 
-func makeValidationError(err error, v reflect.Value) error {
+func makeValidationError(err error, typ reflect.Type) error {
 	if errmap, ok := err.(validator.ErrorMap); ok {
 		errkeys := make([]string, 0, len(errmap))
 		errlist := make(errorList, 0, len(errmap))
@@ -221,7 +221,7 @@ func makeValidationError(err error, v reflect.Value) error {
 		sort.Strings(errkeys)
 
 		for _, errkey := range errkeys {
-			path := fieldPath(v.Type(), errkey)
+			path := fieldPath(typ, errkey)
 
 			if len(errmap[errkey]) == 1 {
 				errlist = append(errlist, fmt.Errorf("invalid value passed to %s: %s", path, errmap[errkey][0]))

--- a/load_test.go
+++ b/load_test.go
@@ -340,6 +340,22 @@ func TestCommand(t *testing.T) {
 	})
 }
 
+func TestValidator(t *testing.T) {
+	config := struct {
+		A struct {
+			Bind string `conf:"bind" validate:"nonzero"`
+		}
+	}{}
+
+	_, _, err := (Loader{}).Load(&config)
+
+	if err == nil {
+		t.Error("bad error:", err)
+	} else {
+		t.Log(err)
+	}
+}
+
 func parseURL(s string) url.URL {
 	u, _ := url.Parse(s)
 	return *u

--- a/print.go
+++ b/print.go
@@ -37,7 +37,21 @@ func (ld Loader) FprintHelp(w io.Writer, cfg interface{}) {
 }
 
 func (ld Loader) fprintError(w io.Writer, err error, col colors) {
-	fmt.Fprintf(w, "%s\n  %s\n\n", col.titles("Error:"), col.errors(err.Error()))
+	var errors errorList
+
+	if e, ok := err.(errorList); ok {
+		errors = e
+	} else {
+		errors = errorList{err}
+	}
+
+	fmt.Fprintf(w, "%s\n", col.titles("Error:"))
+
+	for _, e := range errors {
+		fmt.Fprintf(w, "  %s\n", col.errors(e.Error()))
+	}
+
+	fmt.Fprintln(w)
 }
 
 func (ld Loader) fprintHelp(w io.Writer, cfg interface{}, col colors) {

--- a/type.go
+++ b/type.go
@@ -88,3 +88,28 @@ func makeStructField(f reflect.StructField) reflect.StructField {
 func isExported(f reflect.StructField) bool {
 	return len(f.PkgPath) == 0
 }
+
+func fieldPath(typ reflect.Type, path string) string {
+	var name string
+
+	if sep := strings.IndexByte(path, '.'); sep >= 0 {
+		name, path = path[:sep], path[sep+1:]
+	} else {
+		name, path = path, ""
+	}
+
+	if field, ok := typ.FieldByName(name); ok {
+		if name = field.Tag.Get("conf"); len(name) == 0 {
+			name = field.Name
+		}
+		if len(path) != 0 {
+			path = fieldPath(field.Type, path)
+		}
+	}
+
+	if len(path) != 0 {
+		name += "." + path
+	}
+
+	return name
+}

--- a/type_test.go
+++ b/type_test.go
@@ -1,0 +1,74 @@
+package conf
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFieldPath(t *testing.T) {
+	tests := []struct {
+		value  interface{}
+		input  string
+		output string
+	}{
+		{
+			value:  struct{}{},
+			input:  "",
+			output: "",
+		},
+		{
+			value:  struct{ A int }{},
+			input:  "A",
+			output: "A",
+		},
+		{
+			value:  struct{ A int }{},
+			input:  "1.2.3",
+			output: "1.2.3",
+		},
+		{
+			value: struct {
+				A int `conf:"a"`
+			}{},
+			input:  "A",
+			output: "a",
+		},
+		{
+			value: struct {
+				A int `conf:"a"`
+			}{},
+			input:  "a",
+			output: "a",
+		},
+		{
+			value: struct {
+				A struct {
+					B struct {
+						C int `conf:"c"`
+					} `conf:"b"`
+				} `conf:"a"`
+			}{},
+			input:  "A.B.C",
+			output: "a.b.c",
+		},
+		{
+			value: struct {
+				A struct {
+					B struct {
+						C int `conf:"c"`
+					} `conf:"b"`
+				} `conf:"a"`
+			}{},
+			input:  "A.B",
+			output: "a.b",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			if output := fieldPath(reflect.TypeOf(test.value), test.input); output != test.output {
+				t.Error(output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
@tejasmanohar 
@f2prateek 

This adds support for a `validate` tag on the config. Technically this could be done outside of the conf package but besides being handy it also allows the validation errors to be printed with the usage message.