### PR TITLE
Make prefix optional for env source

### DIFF
--- a/source.go
+++ b/source.go
@@ -51,7 +51,11 @@ func (f SourceFunc) Load(dst Map) error {
 // will be looking at.
 func NewEnvSource(prefix string, env ...string) Source {
 	vars := makeEnvVars(env)
-	base := append(make([]string, 0, 10), prefix)
+	base := make([]string, 0, 10)
+
+	if prefix != "" {
+		base = append(base, prefix)
+	}
 
 	return SourceFunc(func(dst Map) (err error) {
 		dst.Scan(func(path []string, item MapItem) {


### PR DESCRIPTION
Right now if you omit prefix, it'll look for `_SETTING` env var instead of `SETTING`.