### PR TITLE
fix breaking change

### DIFF
--- a/node.go
+++ b/node.go
@@ -477,7 +477,7 @@ func (m Map) EncodeValue(e objconv.Encoder) error {
 	i := 0
 	return e.EncodeMap(m.Len(), func(ke objconv.Encoder, ve objconv.Encoder) (err error) {
 		item := m.items.nodes[i]
-		if err = ke.EncodeString(item.Name); err != nil {
+		if err = ke.Encode(item.Name); err != nil {
 			return
 		}
 		if err = item.Value.EncodeValue(ve); err != nil {


### PR DESCRIPTION
cc @achille-roussel 

Recent objconv change broke a bunch of stuff.

```
../conf/node.go:480: ke.EncodeString undefined (type objconv.Encoder has no field or method EncodeString, but does have objconv.encodeString)
```

This passes locally but panics in circle.