### PR TITLE
add conf.PPROF

### DIFF
--- a/pprof.go
+++ b/pprof.go
@@ -12,8 +12,8 @@ import "runtime"
 //	conf.SetPPROF(config.PPROF)
 //
 type PPROF struct {
-	BlockProfileRate     float64 `conf:"block-profile-rate"     help:"Sets the mutex profile fraction to enable runtime profiling of lock contention, zero disables mutex profiling" validate:"min=0,max=1"`
-	MutexProfileFraction float64 `conf:"mutex-profile-fraction" help:"Sets the mutex profile fraction to enable runtime profiling of lock contention, zero disables mutex profiling" validate:"min=0,max=1"`
+	BlockProfileRate     int `conf:"block-profile-rate"     help:"Sets the mutex profile fraction to enable runtime profiling of lock contention, zero disables mutex profiling" validate:"min=0,max=1"`
+	MutexProfileFraction int `conf:"mutex-profile-fraction" help:"Sets the mutex profile fraction to enable runtime profiling of lock contention, zero disables mutex profiling" validate:"min=0,max=1"`
 }
 
 // DefaultPPROF returns the default value of a PPROF struct. Note that the
@@ -21,12 +21,12 @@ type PPROF struct {
 // configuration of the program's runtime.
 func DefaultPPROF() PPROF {
 	return PPROF{
-		MutexProfileFraction: 1 / float64(runtime.SetMutexProfileFraction(-1)),
+		MutexProfileFraction: runtime.SetMutexProfileFraction(-1),
 	}
 }
 
 // SetPPROF configures the runtime profilers based on the given PPROF config.
 func SetPPROF(config PPROF) {
-	runtime.SetBlockProfileRate(int(1 / config.BlockProfileRate))
-	runtime.SetMutexProfileFraction(int(1 / config.MutexProfileFraction))
+	runtime.SetBlockProfileRate(config.BlockProfileRate)
+	runtime.SetMutexProfileFraction(config.MutexProfileFraction)
 }

--- a/pprof.go
+++ b/pprof.go
@@ -4,6 +4,13 @@ import "runtime"
 
 // PPROF is a confiuration struct which can be used to configure the runtime
 // profilers of programs.
+//
+//	config := struct{
+//		PPROF `conf:"pprof"`
+//	}
+//	conf.Load(&config)
+//	conf.SetPPROF(config.PPROF)
+//
 type PPROF struct {
 	BlockProfileRate     float64 `conf:"block-profile-rate"     help:"Sets the mutex profile fraction to enable runtime profiling of lock contention, zero disables mutex profiling" validate:"min=0,max=1"`
 	MutexProfileFraction float64 `conf:"mutex-profile-fraction" help:"Sets the mutex profile fraction to enable runtime profiling of lock contention, zero disables mutex profiling" validate:"min=0,max=1"`

--- a/pprof.go
+++ b/pprof.go
@@ -14,7 +14,7 @@ import "runtime"
 //	conf.SetPPROF(config.PPROF)
 //
 type PPROF struct {
-	BlockProfileRate     int `conf:"block-profile-rate"     help:"Sets the mutex profile fraction to enable runtime profiling of lock contention, zero disables mutex profiling" validate:"min=0,max=1"`
+	BlockProfileRate     int `conf:"block-profile-rate"     help:"Sets the block profile rate to enable runtime profiling of blocking operations, zero disables block profiling" validate:"min=0,max=1"`
 	MutexProfileFraction int `conf:"mutex-profile-fraction" help:"Sets the mutex profile fraction to enable runtime profiling of lock contention, zero disables mutex profiling" validate:"min=0,max=1"`
 }
 

--- a/pprof.go
+++ b/pprof.go
@@ -1,0 +1,25 @@
+package conf
+
+import "runtime"
+
+// PPROF is a confiuration struct which can be used to configure the runtime
+// profilers of programs.
+type PPROF struct {
+	BlockProfileRate     float64 `conf:"block-profile-rate"     help:"Sets the mutex profile fraction to enable runtime profiling of lock contention, zero disables mutex profiling" validate:"min=0,max=1"`
+	MutexProfileFraction float64 `conf:"mutex-profile-fraction" help:"Sets the mutex profile fraction to enable runtime profiling of lock contention, zero disables mutex profiling" validate:"min=0,max=1"`
+}
+
+// DefaultPPROF returns the default value of a PPROF struct. Note that the
+// zero-value is valid, DefaultPPROF differs because it captures the current
+// configuration of the program's runtime.
+func DefaultPPROF() PPROF {
+	return PPROF{
+		MutexProfileFraction: 1 / float64(runtime.SetMutexProfileFraction(-1)),
+	}
+}
+
+// SetPPROF configures the runtime profilers based on the given PPROF config.
+func SetPPROF(config PPROF) {
+	runtime.SetBlockProfileRate(int(1 / config.BlockProfileRate))
+	runtime.SetMutexProfileFraction(int(1 / config.MutexProfileFraction))
+}

--- a/pprof.go
+++ b/pprof.go
@@ -2,7 +2,7 @@ package conf
 
 import "runtime"
 
-// PPROF is a confiuration struct which can be used to configure the runtime
+// PPROF is a configuration struct which can be used to configure the runtime
 // profilers of programs.
 //
 //	config := struct{

--- a/pprof.go
+++ b/pprof.go
@@ -7,6 +7,8 @@ import "runtime"
 //
 //	config := struct{
 //		PPROF `conf:"pprof"`
+//	}{
+//		PPROF: conf.DefaultPPROF(),
 //	}
 //	conf.Load(&config)
 //	conf.SetPPROF(config.PPROF)


### PR DESCRIPTION
This PR adds a configuration data structure which can be used to configure the runtime profilers that are not enabled by default.
