### PR TITLE
Add mod tag an allow modification of the data

### DIFF
--- a/load.go
+++ b/load.go
@@ -13,7 +13,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/go-playground/mold/modifiers"
+	"gopkg.in/go-playground/mold.v2/modifiers"
 
 	validator "gopkg.in/validator.v2"
 
@@ -23,7 +23,10 @@ import (
 )
 
 var (
-	mod = modifiers.New()
+	// Modifier is the default modification lib using the "mod" tag; it is
+	// exposed to allow registering of custom modifiers and aliases or to
+	// be set to a more central instance located in another repo.
+	Modifier = modifiers.New()
 )
 
 // Load the program's configuration into cfg, and returns the list of leftover
@@ -146,7 +149,7 @@ func (ld Loader) Load(cfg interface{}) (cmd string, args []string, err error) {
 		return
 	}
 
-	if err = mod.Struct(context.Background(), cfg); err != nil {
+	if err = Modifier.Struct(context.Background(), cfg); err != nil {
 		return
 	}
 

--- a/load.go
+++ b/load.go
@@ -2,6 +2,7 @@ package conf
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -12,11 +13,17 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/go-playground/mold/modifiers"
+
 	validator "gopkg.in/validator.v2"
 
 	// Load all default adapters of the objconv package.
 	_ "github.com/segmentio/objconv/adapters"
 	"github.com/segmentio/objconv/yaml"
+)
+
+var (
+	mod = modifiers.New()
 )
 
 // Load the program's configuration into cfg, and returns the list of leftover
@@ -136,6 +143,10 @@ func (ld Loader) Load(cfg interface{}) (cmd string, args []string, err error) {
 	}
 
 	if args, err = ld.load(v); err != nil {
+		return
+	}
+
+	if err = mod.Struct(context.Background(), cfg); err != nil {
 		return
 	}
 

--- a/load_test.go
+++ b/load_test.go
@@ -407,6 +407,22 @@ func TestValidator(t *testing.T) {
 	}
 }
 
+func TestModifiers(t *testing.T) {
+	config := struct {
+		Email string `conf:"bind" validate:"nonzero" mod:"trim,lcase"`
+	}{
+		Email: " Test.Email@email.com",
+	}
+
+	_, _, err := (Loader{}).Load(&config)
+	if err != nil {
+		t.Error("bad error:", err)
+	}
+	if config.Email != "test.email@email.com" {
+		t.Error("bad mod value:", config.Email)
+	}
+}
+
 func parseURL(s string) url.URL {
 	u, _ := url.Parse(s)
 	return *u

--- a/load_test.go
+++ b/load_test.go
@@ -409,7 +409,7 @@ func TestValidator(t *testing.T) {
 
 func TestModifiers(t *testing.T) {
 	config := struct {
-		Email string `conf:"bind" validate:"nonzero" mod:"trim,lcase"`
+		Email string `conf:"email" validate:"nonzero" mod:"trim,lcase"`
 	}{
 		Email: " Test.Email@email.com",
 	}


### PR DESCRIPTION
This add support for the `mod` tag to allow cleaning/manipulation of the information prior to validation eg.
```go
package main

import (
	"fmt"

	"github.com/segmentio/conf"
)

func main() {
	config := struct {
		Username string `conf:"username" validate:"nonzero"`
		Password string `conf:"password" validate:"nonzero"`
	}{
		Username: "   ", // simulated user input data or ENV variable, USERNAME="   " go run main.go
		Password: "mypass",
	}
	conf.Load(&config)
	fmt.Println("should have failed, now up to us to strings.TrimSpace() + validate again")
}
```

using mod(completely optional)
```go
package main

import (
	"fmt"

	"github.com/segmentio/conf"
)

func main() {
	config := struct {
		Username string `conf:"username" validate:"nonzero" mod:"trim,lcase"`
		Password string `conf:"password" validate:"nonzero"`
	}{
		Username: "   ", // simulated user input data or ENV variable, USERNAME="   " go run main.go
		Password: "mypass",
	}
	conf.Load(&config)
	fmt.Println("failed as expected")
}
```

This is useful when dealing with data that is not guaranteed to be clean like data end users/clients/customers have the ability to modify. An argument could be made to ensure the data is valid when saving, but it's not always possible, even though that is the preferred option.

I understand if you don't want to add this, I for one would have used it on several occasions already and why I decided to give the option via a PR