### PR TITLE
add json template function to allow escaping of environment variables

### DIFF
--- a/load_test.go
+++ b/load_test.go
@@ -338,6 +338,30 @@ points:
 	}
 }
 
+func TestTemplateFunc(t *testing.T) {
+	const configFile = "/tmp/conf-json-test.yml"
+	ioutil.WriteFile(configFile, []byte(`---
+hello: {{ .NAME | json }}
+`), 0644)
+	defer os.Remove(configFile)
+
+	var cfg struct {
+		Hello string `conf:"hello"`
+	}
+
+	_, _, err := defaultLoader([]string{"test", "-config-file", configFile}, []string{
+		"NAME=first: Luke, second: Leia",
+	}).Load(&cfg)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if cfg.Hello != "first: Luke, second: Leia" {
+		t.Error("bad value:", cfg.Hello)
+	}
+}
+
 func TestCommand(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		ld := Loader{

--- a/source.go
+++ b/source.go
@@ -3,8 +3,10 @@ package conf
 import (
 	"bytes"
 	"flag"
-	"html/template"
 	"strings"
+	"text/template"
+
+	"github.com/segmentio/objconv/json"
 )
 
 // Source is the interface that allow new types to be plugged into a loader to
@@ -119,6 +121,13 @@ func (f *fileSource) Load(dst Map) (err error) {
 	tpl := template.New(f.flag)
 	buf := &bytes.Buffer{}
 	buf.Grow(len(b))
+
+	tpl = tpl.Funcs(template.FuncMap{
+		"json": func(v interface{}) (string, error) {
+			b, err := json.Marshal(v)
+			return string(b), err
+		},
+	})
 
 	if _, err = tpl.Parse(string(b)); err != nil {
 		return


### PR DESCRIPTION
Fixes #20 

The idea here is to allow escaping of environment variables into JSON values (which are compatible with YAML).

Please take a look and let me know if something should be changed.