### PR TITLE
prettier types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/segmentio/conf
+
+require (
+	github.com/segmentio/go-snakecase v1.1.0 // indirect
+	github.com/segmentio/objconv v1.0.1
+	gopkg.in/go-playground/mold.v2 v2.2.0
+	gopkg.in/validator.v2 v2.0.0-20180514200540-135c24b11c19
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/segmentio/go-snakecase v1.1.0 h1:ZJO4SNKKV0MjGOv0LHnixxN5FYv1JKBnVXEuBpwcbQI=
+github.com/segmentio/go-snakecase v1.1.0/go.mod h1:jk1miR5MS7Na32PZUykG89Arm+1BUSYhuGR6b7+hJto=
+github.com/segmentio/objconv v1.0.1 h1:QjfLzwriJj40JibCV3MGSEiAoXixbp4ybhwfTB8RXOM=
+github.com/segmentio/objconv v1.0.1/go.mod h1:auayaH5k3137Cl4SoXTgrzQcuQDmvuVtZgS0fb1Ahys=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/go-playground/mold.v2 v2.2.0 h1:Y4IYB4/HYQfuq43zaKh6vs9cVelLE9qbqe2fkyfCTWQ=
+gopkg.in/go-playground/mold.v2 v2.2.0/go.mod h1:XMyyRsGtakkDPbxXbrA5VODo6bUXyvoDjLd5l3T0XoA=
+gopkg.in/validator.v2 v2.0.0-20180514200540-135c24b11c19 h1:WB265cn5OpO+hK3pikC9hpP1zI/KTwmyMFKloW9eOVc=
+gopkg.in/validator.v2 v2.0.0-20180514200540-135c24b11c19/go.mod h1:o4V0GXN9/CAmCsvJ0oXYZvrZOe7syiDZSN1GWGZTGzc=
+gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
+gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/node_test.go
+++ b/node_test.go
@@ -341,7 +341,7 @@ func TestNodeString(t *testing.T) {
 			node: Scalar{reflect.ValueOf("Hello World!")},
 		},
 		{
-			repr: `"2016-12-31T23:42:59Z"`,
+			repr: `2016-12-31T23:42:59Z`,
 			node: Scalar{reflect.ValueOf(date)},
 		},
 		{

--- a/node_test.go
+++ b/node_test.go
@@ -341,7 +341,7 @@ func TestNodeString(t *testing.T) {
 			node: Scalar{reflect.ValueOf("Hello World!")},
 		},
 		{
-			repr: `2016-12-31T23:42:59Z`,
+			repr: `"2016-12-31T23:42:59Z"`,
 			node: Scalar{reflect.ValueOf(date)},
 		},
 		{
@@ -373,7 +373,9 @@ func TestNodeString(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.repr, func(t *testing.T) {
 			if repr := test.node.String(); repr != test.repr {
-				t.Error(repr)
+				t.Error("representation mismatch")
+				t.Log("expected:", test.repr)
+				t.Log("found:   ", repr)
 			}
 		})
 	}
@@ -471,12 +473,12 @@ func Test_FlattenedEmbeddedStructs(t *testing.T) {
 	}
 
 	type Medium struct {
-		Small `conf:"_"`
+		Small     `conf:"_"`
 		MediumOne string
 	}
 
 	type Matroska struct {
-		Medium `conf:"_"`
+		Medium   `conf:"_"`
 		LargeOne string
 	}
 
@@ -523,17 +525,17 @@ func Test_InvalidFlattenedEmbeddedStructs(t *testing.T) {
 	tests := []struct {
 		val          interface{}
 		errFragments []string
-	} {
+	}{
 		{
-			val: ConflictingName{},
+			val:          ConflictingName{},
 			errFragments: []string{"'Stuff'", "duplicate"},
 		},
 		{
-			val: EmbedPrimitive{},
+			val:          EmbedPrimitive{},
 			errFragments: []string{"\"_\"", "at path EmbedPrimitive.Str"},
 		},
 		{
-			val: EmbedNamedStruct{},
+			val:          EmbedNamedStruct{},
 			errFragments: []string{"\"_\"", "at path EmbedNamedStruct.Thing"},
 		},
 	}

--- a/print.go
+++ b/print.go
@@ -193,7 +193,11 @@ func prettyType(t reflect.Type) string {
 	case reflect.Ptr:
 		return prettyType(t.Elem())
 	default:
-		return t.String()
+		s := strings.ToLower(t.String())
+		if i := strings.LastIndexByte(s, '.'); i >= 0 {
+			s = s[i+1:]
+		}
+		return s
 	}
 }
 

--- a/print_test.go
+++ b/print_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+type Bytes uint64
+
 func TestPrettyType(t *testing.T) {
 	tests := []struct {
 		v interface{}
@@ -43,6 +45,8 @@ func TestPrettyType(t *testing.T) {
 		{map[int]int{}, "object"},
 		{struct{}{}, "object"},
 		{&struct{}{}, "object"},
+
+		{Bytes(0), "bytes"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR changes the default display of type names to be more user friendly when custom Go types are employed.

Before this change, if we used a custom type it would be rendered as `<package>.<Type>` in the help message of the program.

After this change, the same type will be rendered as `<type>` (all lower-case and omitting the package name), which often creates a better experience for the end user.