### PR TITLE
print defaults for booleans when appropriate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/segmentio/conf
 
 require (
+	github.com/google/go-cmp v0.3.0
 	github.com/segmentio/go-snakecase v1.1.0 // indirect
 	github.com/segmentio/objconv v1.0.1
 	gopkg.in/go-playground/mold.v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
+github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/segmentio/go-snakecase v1.1.0 h1:ZJO4SNKKV0MjGOv0LHnixxN5FYv1JKBnVXEuBpwcbQI=
 github.com/segmentio/go-snakecase v1.1.0/go.mod h1:jk1miR5MS7Na32PZUykG89Arm+1BUSYhuGR6b7+hJto=
 github.com/segmentio/objconv v1.0.1 h1:QjfLzwriJj40JibCV3MGSEiAoXixbp4ybhwfTB8RXOM=

--- a/print.go
+++ b/print.go
@@ -144,8 +144,17 @@ func (ld Loader) fprintHelp(w io.Writer, cfg interface{}, col colors) {
 			h = append(h, s)
 		}
 
-		if s := f.DefValue; len(s) != 0 && !empty && !(boolean || object || list) {
-			h = append(h, col.defvals("(default "+s+")"))
+		if s := f.DefValue; len(s) != 0 {
+			switch {
+			case empty, object, list:
+			case boolean:
+				if s == "false" {
+					break
+				}
+				fallthrough
+			default:
+				h = append(h, col.defvals("(default "+s+")"))
+			}
 		}
 
 		if len(h) != 0 {

--- a/print_test.go
+++ b/print_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 type Bytes uint64
@@ -85,8 +87,9 @@ func TestPrintHelp(t *testing.T) {
 		C int
 		D bool `help:"Set D"`
 		E bool `conf:"enable" help:"Enable E"`
+		F bool `help:"run in super mode"`
 		T time.Duration
-	}{A: 1, T: time.Second})
+	}{A: 1, F: true, T: time.Second})
 
 	const txt = "Usage:\n" +
 		"  test [command] [options...]\n" +
@@ -105,6 +108,8 @@ func TestPrintHelp(t *testing.T) {
 		"\n" +
 		"  -D\tSet D\n" +
 		"\n" +
+		"  -F\trun in super mode (default true)\n" +
+		"\n" +
 		"  -T duration\n" +
 		"    \t(default 1s)\n" +
 		"\n" +
@@ -112,9 +117,7 @@ func TestPrintHelp(t *testing.T) {
 		"    \tEnable E\n" +
 		"\n"
 
-	if s := b.String(); s != txt {
-		t.Error(s)
-		t.Error(txt)
-		t.Error(len(s), len(txt))
+	if diff := cmp.Diff(txt, b.String()); diff != "" {
+		t.Error(diff)
 	}
 }


### PR DESCRIPTION
* When a boolean flag defaults to true, we should print that. This matches the stdlib, and is the least surprising thing to do.

* Switch to go-cmp for printing test failure diffs, which makes test failures much easier to spot:
```
--- FAIL: TestPrintHelp (0.00s)
    /Users/jnj/src/github.com/segmentio/conf/print_test.go:121:   strings.Join({
          	... // 15 identical lines
          	`  -D	Set D`,
          	"",
        - 	`  -F	run in super mode (default true)`,
        + 	`  -F	run in super mode`,
          	"",
          	"  -T duration",
          	... // 6 identical lines
          }, "\n")

```