### PR TITLE
Fixing long digit seqs being incorrectly interpreted as numbers

### DIFF
--- a/load_test.go
+++ b/load_test.go
@@ -153,6 +153,12 @@ var (
 			args: []string{"-A", "42"},
 			env:  []string{"TEST_A=42"},
 		},
+		{
+			val:  struct{ A string }{"0123456789"}, // convert a longer digit sequence to string
+			file: `A: '0123456789'`,
+			args: []string{"-A", "0123456789"},
+			env:  []string{"TEST_A=0123456789"},
+		},
 
 		{
 			val:  struct{ S string }{"Hello World!"},
@@ -515,12 +521,12 @@ func TestEmbeddedStruct(t *testing.T) {
 	}
 
 	type Branch struct {
-		Child `conf:"_"`
+		Child       `conf:"_"`
 		BranchField string
 	}
 
 	type Container struct {
-		Branch `conf:"_"`
+		Branch      `conf:"_"`
 		OtherBranch Branch
 	}
 

--- a/node.go
+++ b/node.go
@@ -213,7 +213,7 @@ func populateNodeStruct(originalT reflect.Type, path string, v reflect.Value, t 
 			path = path + "." + ft.Name
 			if ft.Type.Kind() != reflect.Struct || !ft.Anonymous {
 				panic("found \"_\" on invalid type at path " + path + " in configuration: " + originalT.Name())
- 			}
+			}
 			populateNodeStruct(originalT, path, fv, ft.Type, m)
 			continue
 		case "":
@@ -308,8 +308,13 @@ func (s Scalar) Set(str string) (err error) {
 			err = fmt.Errorf("%s", x)
 		}
 	}()
-	ptr := s.value.Addr().Interface()
 
+	if s.value.Kind() == reflect.String {
+		s.value.SetString(str)
+		return
+	}
+
+	ptr := s.value.Addr().Interface()
 	if err = yaml.Unmarshal([]byte(str), ptr); err != nil {
 		if b, _ := json.Marshal(str); b != nil {
 			if json.Unmarshal(b, ptr) == nil {


### PR DESCRIPTION
The intent is to skip yaml/json parsing if the destination field type is `string`. Otherwise unquoted digit sequences may be distorted by the parsers.

## Showcase
```package main

import (
	"fmt"

	"github.com/segmentio/conf"
)

func main() {
	config := struct {
		A string `conf:"a"`
	}{}

	conf.LoadWith(&config, conf.Loader{
		Name: "showcase",
		Args: []string{"--a=0123456789"},
	})

	fmt.Printf("A='%s'\n", config.A)
}
```
Before the fix this would give you 
```
A='1.23456789e+08'
```
