### PR TITLE
Make the global validator and mold transformer instances interfaces

### DIFF
--- a/load.go
+++ b/load.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"gopkg.in/go-playground/mold.v2/modifiers"
-
 	validator "gopkg.in/validator.v2"
 
 	// Load all default adapters of the objconv package.
@@ -22,11 +21,16 @@ import (
 	"github.com/segmentio/objconv/yaml"
 )
 
+// MoldTransformer decouples Modifier from the concrete type and lets client code to replace its implementation
+type MoldTransformer interface {
+	Struct(context.Context, interface{}) error
+}
+
 var (
 	// Modifier is the default modification lib using the "mod" tag; it is
 	// exposed to allow registering of custom modifiers and aliases or to
 	// be set to a more central instance located in another repo.
-	Modifier = modifiers.New()
+	Modifier MoldTransformer = modifiers.New()
 )
 
 // Load the program's configuration into cfg, and returns the list of leftover

--- a/load.go
+++ b/load.go
@@ -13,24 +13,29 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/go-playground/mold.v2/modifiers"
-	validator "gopkg.in/validator.v2"
-
 	// Load all default adapters of the objconv package.
 	_ "github.com/segmentio/objconv/adapters"
 	"github.com/segmentio/objconv/yaml"
+	"gopkg.in/go-playground/mold.v2/modifiers"
+	validator "gopkg.in/validator.v2"
 )
 
-// MoldTransformer decouples Modifier from the concrete type and lets client code to replace its implementation
+// MoldTransformer decouples Modifier from the concrete type and lets client code replace its implementation
 type MoldTransformer interface {
 	Struct(context.Context, interface{}) error
+}
+
+// ValidatorInterface decouples Validator from the concrete type and lets client code replace its implementation
+type ValidatorInterface interface {
+	Validate(interface{}) error
 }
 
 var (
 	// Modifier is the default modification lib using the "mod" tag; it is
 	// exposed to allow registering of custom modifiers and aliases or to
 	// be set to a more central instance located in another repo.
-	Modifier MoldTransformer = modifiers.New()
+	Modifier  MoldTransformer    = modifiers.New()
+	Validator ValidatorInterface = validator.NewValidator()
 )
 
 // Load the program's configuration into cfg, and returns the list of leftover
@@ -157,7 +162,7 @@ func (ld Loader) Load(cfg interface{}) (cmd string, args []string, err error) {
 		return
 	}
 
-	if err = validator.Validate(v.Interface()); err != nil {
+	if err = Validator.Validate(v.Interface()); err != nil {
 		err = makeValidationError(err, v.Type())
 	}
 


### PR DESCRIPTION
I noticed that loading configuration into a recursive structure fails with `fatal error: stack overflow` even though `conf:"-"` is set on the recursive field. 

The endless recursion actually happens in the go-playground/validator and go-playground/mold packages which I don't care for. I'd like to be able to load into recursive structures though but currently there's no way to turn them off.

# Showcase
```
func TestPanic(t *testing.T) {
	type Nested struct {
		Param string      `conf:"param"`
		Other interface{} `conf:"-"`
	}

	cfg := Nested{}
	cfg.Other = &cfg

	LoadWith(&cfg, Loader{
		Name: "test",
		Args: []string{"-param=val"},
	})
}
```

`fatal error: stack overflow`

# Solution

This PR replaces global variables of concrete Validator and Transformer types from those packages with global interfaces that can be replaced from client code with no-op implementations that don't get into infinite recursion.

This provides a fully backwards-compatible solution that doesn't require pollution of configuration structures with flags like `DisableValidation bool` or `DisableModification bool`.

```
type playgroundNoop struct{}

func (p playgroundNoop) Validate(interface{}) error {
	return nil
}

func (p playgroundNoop) Struct(context.Context, interface{}) error {
	return nil
}

func init() {
	conf.Modifier = playgroundNoop{}
	conf.Validator = playgroundNoop{}
}
```