### PR TITLE
Updating CircleCI config to fix the build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/segmentio/conf
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.12
     steps:
       - run: git clone https://github.com/segmentio/conf.git /go/src/github.com/segmentio/conf
       - run: go get -v -t ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/segmentio/conf
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.12
     steps:
       - run: git clone https://github.com/segmentio/conf.git /go/src/github.com/segmentio/conf
       - run: go get -v -t ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/segmentio/conf
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.13
     steps:
       - run: git clone https://github.com/segmentio/conf.git /go/src/github.com/segmentio/conf
       - run: go get -v -t ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,7 @@ jobs:
     docker:
       - image: circleci/golang
     steps:
-      - checkout
-      - setup_remote_docker: { reusable: true, docker_layer_caching: true }
+      - run: git clone https://github.com/segmentio/conf.git /go/src/github.com/segmentio/conf
       - run: go get -v -t ./...
       - run: go vet ./...
       - run: go test -v -race ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/segmentio/conf
     docker:
-      - image: circleci/golang
+      - image: circleci/golang:1.11
     steps:
       - run: git clone https://github.com/segmentio/conf.git /go/src/github.com/segmentio/conf
       - run: go get -v -t ./...


### PR DESCRIPTION
## Switched it to checkout via https
If I find somebody who can refresh the ssh key in this project, I'll change it back.

## Pinned go version to 1.12
On go versions 1.13+ [one of the tests fail](https://app.circleci.com/pipelines/github/segmentio/conf/6/workflows/7012d039-dfd1-4d8d-9179-4d016eefbbca/jobs/139)
But it passes if you [revert this commit](https://github.com/segmentio/conf/commit/e96e43fe5cc126495d16a27584bb75ab728d8efe) and put the quotes back in. @achille-roussel do you remember what happened there?