### PR TITLE
all: fix spelling errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ configuration values. It also has support for sub-commands on the command line,
 which is a common approach used by CLI tools.
 
 - **Supporting multiple sources**, because passing values through the command
-line is not always the best appraoch, programs may need to receive their
+line is not always the best approach, programs may need to receive their
 configuration from files, environment variables, secret stores, or other network
 locations.
 
@@ -195,7 +195,7 @@ Hello World!
 Custom Sources
 --------------
 
-We mentionned the `conf.Loader` type supported setting custom sources that the
+We mentioned the `conf.Loader` type supported setting custom sources that the
 program configuration can be loaded from. Here's the the `conf.Source` interface
 definition:
 ```go

--- a/load.go
+++ b/load.go
@@ -41,7 +41,7 @@ var (
 // configuration file if the -config-file option is present in the program
 // arguments.
 //
-// Values found in the progrma arguments take precedence over those found in
+// Values found in the program arguments take precedence over those found in
 // the environment, which takes precedence over the configuration file.
 //
 // If an error is detected with the configurable the function print the usage

--- a/node_test.go
+++ b/node_test.go
@@ -120,7 +120,7 @@ func TestEqualNode(t *testing.T) {
 		},
 
 		{
-			name: "non-equal arrays (length mistmatch)",
+			name: "non-equal arrays (length mismatch)",
 			node1: Array{items: newArrayItems(
 				Scalar{reflect.ValueOf(1)},
 				Scalar{reflect.ValueOf(2)},
@@ -558,7 +558,7 @@ func Test_InvalidFlattenedEmbeddedStructs(t *testing.T) {
 			}()
 
 			makeNodeStruct(reflect.ValueOf(tt.val), reflect.TypeOf(tt.val))
-			t.Error("test should have paniced")
+			t.Error("test should have panicked")
 		})
 	}
 }

--- a/source.go
+++ b/source.go
@@ -13,9 +13,9 @@ import (
 // make it possible to load configuration from new places.
 //
 // When the configuration is loaded the Load method of each source that was set
-// on a loader is called with an Node representating the configuration struct.
-// The typical implementation of a source is to load the serialized version of
-// the configuration and use an objconv decoder to build the node.
+// on a loader is called with a Node representing the configuration struct. The
+// typical implementation of a source is to load the serialized version of the
+// configuration and use an objconv decoder to build the node.
 type Source interface {
 	Load(dst Map) error
 }


### PR DESCRIPTION
I spotted "progrma" and then found the rest of these using the `codespell` tool which I am definitely going to use more often.